### PR TITLE
Add first Lassa posts

### DIFF
--- a/experiments/lassa/index.md
+++ b/experiments/lassa/index.md
@@ -1,7 +1,28 @@
 ---
 layout: doc
+aside: false
+dir: 'lassa'
+title: Lassa
+subtext: Pseudovirus deep mutational scanning of the Lassa virus glycoprotein complex (GPC).
+pins:
+  - title: Effects of mutations on cell entry
+    link: /experiments/lassa/posts/LASV_Josiah_GPC_cell_entry
+    details: Here is the best data to checkout if you're interested in effects of mutations on cell entry
+    linkText: Check it out!
+  - title: Effects of mutations on antibody escape
+    details: Here are results from mapping neutralizing activity of monoclonal anti-GPC antibodies
+    link: /experiments/lassa/posts/LASV_Josiah_GPC_antibody_escape
+    linkText: Check it out!
 ---
 
-# Lassa
+<Header :title="$frontmatter.title" :description="$frontmatter.subtext" /> 
 
-In Progress...
+<PinnedExperiments />
+
+<!-- Edit below -->
+## Lassa Glycoprotein deep mutational scanning datasets
+
+The pinned posts above include the most up to date data on the effects of mutations on cell entry and antibody escape for Lassa glycoprotein. For a list of all the studies using the lentiviral deep mutational scanning system for Lassa glycoprotein, see the experiments section below.
+<!-- Stop editing -->
+
+<Experiments :currentDirectory="$frontmatter.dir" />

--- a/experiments/lassa/posts/LASV_Josiah_GPC_antibody_escape.md
+++ b/experiments/lassa/posts/LASV_Josiah_GPC_antibody_escape.md
@@ -1,0 +1,63 @@
+---
+title: 'Effects of mutations on antibody neutralization'
+aside: false
+author: 
+    - Caleb Carr
+    - Kate Crawford
+date: 2024-02-06
+github: https://github.com/dms-vep/LASV_Josiah_GP_DMS
+paper: https://www.biorxiv.org/content/10.1101/2024.02.05.579020v1
+keywords:
+    - Josiah
+    - Lassa glycoprotein
+    - Lentiviral Pseudotyping
+    - antibody escape
+    - 25.10C
+    - 12.1F
+    - 37.7H
+    - 25.6A
+    - 37.2D
+    - 8.9F
+---
+
+# {{ $frontmatter.title }}
+
+Study by {{ $frontmatter.author.join(', ') }}, et al. The study is available <a v-bind:href="$frontmatter.paper">here</a>.
+
+## Effects of mutations to Lassa Josiah strain glycoprotein on antibody neutralization
+
+Plot below shows how mutations to Lassa Josiah strain glycoprotein affect antibody neutralization.   
+
+These are interactive charts. Mouseover points for details and measurements, and use the top zoom bar to zoom in on specific sites. The options at the bottom let you apply or alter a variety of filters and viewing options, such as choosing the site summary metric, only showing escape for sites with some minimal functional effect, or choosing whether to floor the functional effects or escape at zero. 
+
+The line plots at top of each plot show the effects of mutations at each site, and the heatmaps show the effects of individual mutations on cell entry or immune escape.  
+
+Analysis by Carr et al., bioRxiv, DOI [https://doi.org/10.1101/2024.02.05.579020 (2024)](https://www.biorxiv.org/content/10.1101/2024.02.05.579020v1).  
+
+See [https://github.com/dms-vep/LASV_Josiah_GP_DMS](https://github.com/dms-vep/LASV_Josiah_GP_DMS) for code/data.
+
+### Antibody 25.10C escape plot
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/2510C_mut_effect.html'"></Altair>
+
+### Antibody 12.1F escape plot
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/121F_mut_effect.html'"></Altair>
+
+### Antibody 37.7H escape plot
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/377H_mut_effect.html'"></Altair>
+
+### Antibody 25.6A escape plot
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/256A_mut_effect.html'"></Altair>
+
+### Antibody 37.2D escape plot
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/372D_mut_effect.html'"></Altair>
+
+### Antibody 8.9F escape plot
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/89F_mut_effect.html'"></Altair>
+
+

--- a/experiments/lassa/posts/LASV_Josiah_GPC_cell_entry.md
+++ b/experiments/lassa/posts/LASV_Josiah_GPC_cell_entry.md
@@ -1,0 +1,37 @@
+---
+title: 'Effects of mutations on 293T cell entry'
+aside: false
+author: 
+    - Caleb Carr
+    - Kate Crawford
+date: 2024-02-06
+github: https://github.com/dms-vep/LASV_Josiah_GP_DMS
+paper: https://www.biorxiv.org/content/10.1101/2024.02.05.579020v1
+keywords:
+    - Josiah
+    - Lassa glycoprotein
+    - Lentiviral Pseudotyping
+    - cell entry
+---
+
+# {{ $frontmatter.title }}
+
+Study by {{ $frontmatter.author.join(', ') }}, et al. The study is available <a v-bind:href="$frontmatter.paper">here</a>.
+
+## Effects of mutations to Lassa Josiah strain glycoprotein on entry into 293T cells
+
+Plot below shows how mutations to Lassa Josiah strain glycoprotein affect cell entry. All experiments were performed using 293T cells.   
+
+These are interactive charts. Mouseover points for details and measurements, and use the top zoom bar to zoom in on specific sites. The options at the bottom let you apply or alter a variety of filters and viewing options, such as choosing the site summary metric, only showing escape for sites with some minimal functional effect, or choosing whether to floor the functional effects or escape at zero. 
+
+The line plots at top of each plot show the effects of mutations at each site, and the heatmaps show the effects of individual mutations on cell entry or immune escape.  
+
+Analysis by Carr et al., bioRxiv, DOI [https://doi.org/10.1101/2024.02.05.579020 (2024)](https://www.biorxiv.org/content/10.1101/2024.02.05.579020v1).  
+
+See [https://github.com/dms-vep/LASV_Josiah_GP_DMS](https://github.com/dms-vep/LASV_Josiah_GP_DMS) for code/data.
+
+### Effects of mutations on cell entry in the Josiah strain
+
+<Altair :spec-url="'https://dms-vep.org/LASV_Josiah_GP_DMS/htmls/293T_entry_func_effects.html'"></Altair>
+
+

--- a/public/contributors.json
+++ b/public/contributors.json
@@ -18,5 +18,10 @@
         "name": "Will Hannon",
         "image": "https://research.fredhutch.org/content/stripe/bloom/en/members/_jcr_content/par/labmember_13944287/image.img.png/1598649957719.png",
         "link": "https://willhannon.com/"
+    },
+    {
+        "name": "Caleb Carr",
+        "image": "https://research.fredhutch.org/content/stripe/bloom/en/members/_jcr_content/par/labmember_965242551/image.img.jpg/1635439221241.jpg",
+        "link": "https://research.fredhutch.org/bloom/en/members.html"
     }
 ]


### PR DESCRIPTION
This is the first commit with Lassa posts. What was added/edited:

- `lassa/index.md` was updated with information for two main posts (cell entry and antibody escape)
- `lassa/posts/LASV_Josiah_GPC_antibody_escape.md` contains the post for antibody escape plots
- `lassa/posts/LASV_Josiah_GPC_cell_entry.md` contains the post for cell entry effects
- `public/contributors.json` was edited to include Caleb Carr